### PR TITLE
Set width for nav arrow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -904,6 +904,7 @@ nav ul {
     display: inline-block;
     line-height: 1.4;
     font-weight: 900;
+    width:18px;
   }
 
   .nav-menu > .nav-item > [aria-expanded=true]:after {


### PR DESCRIPTION
Things in the nav bar keep moving around on hover because the width of the font-awesome icon changes. Sets an absolute width of 18px.